### PR TITLE
즐겨찾기 추가, 해제 구현

### DIFF
--- a/app/src/main/java/com/gyleedev/chatchat/data/database/dao/FavoriteDao.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/data/database/dao/FavoriteDao.kt
@@ -14,7 +14,10 @@ interface FavoriteDao {
     fun getUsersWithPaging(): PagingSource<Int, FavoriteEntity>
 
     @Query("SELECT * FROM favorite WHERE user_entity_id = :userEntityId")
-    fun getFavoriteByUid(userEntityId: Long): FavoriteEntity
+    fun getFavoriteByUserEntityId(userEntityId: Long): FavoriteEntity
+
+    @Query("SELECT * FROM favorite WHERE favorite_number> :favoriteNumber")
+    fun getFavoritesForSort(favoriteNumber: Long): List<FavoriteEntity>
 
     @Update
     fun updateFavorite(favoriteEntity: FavoriteEntity)

--- a/app/src/main/java/com/gyleedev/chatchat/data/database/dao/UserAndFavoriteDao.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/data/database/dao/UserAndFavoriteDao.kt
@@ -7,6 +7,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Update
+import com.gyleedev.chatchat.data.database.entity.UserAndFavoriteEntity
 import com.gyleedev.chatchat.data.database.entity.UserEntity
 import com.gyleedev.chatchat.domain.UserRelationState
 import kotlinx.coroutines.flow.Flow
@@ -36,7 +37,7 @@ interface UserAndFavoriteDao {
 
     @Transaction
     @Query("SELECT * FROM user WHERE uid = :uid")
-    fun getUserInfoByUid(uid: String): Flow<UserEntity?>
+    fun getUserAndFavoriteByUid(uid: String): Flow<UserAndFavoriteEntity?>
 
     @Transaction
     @Update

--- a/app/src/main/java/com/gyleedev/chatchat/data/database/entity/UserAndFavoriteEntity.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/data/database/entity/UserAndFavoriteEntity.kt
@@ -9,7 +9,7 @@ data class UserAndFavoriteEntity(
     @Embedded val user: UserEntity,
     @Relation(
         parentColumn = "id",
-        entityColumn = "userEntityId"
+        entityColumn = "user_entity_id"
     )
     val favorite: FavoriteEntity
 )
@@ -21,7 +21,7 @@ fun UserAndFavoriteEntity.toLocalData(): RelatedUserLocalData {
         uid = user.uid,
         picture = user.picture,
         status = user.status,
-        favoriteState = user.favoriteState,
+        favoriteState = favorite.favoriteState,
         favoriteNumber = favorite.favoriteNumber,
         userRelation = user.relation,
         name = user.name

--- a/app/src/main/java/com/gyleedev/chatchat/domain/usecase/GetRelatedUserAndFavoriteDataUseCase.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/domain/usecase/GetRelatedUserAndFavoriteDataUseCase.kt
@@ -1,0 +1,14 @@
+package com.gyleedev.chatchat.domain.usecase
+
+import com.gyleedev.chatchat.data.repository.UserRepository
+import com.gyleedev.chatchat.domain.RelatedUserLocalData
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetRelatedUserAndFavoriteDataUseCase @Inject constructor(
+    private val repository: UserRepository
+) {
+    operator fun invoke(uid: String): Flow<RelatedUserLocalData> {
+        return repository.getFriendAndFavoriteByUid(uid)
+    }
+}

--- a/app/src/main/java/com/gyleedev/chatchat/domain/usecase/UpdateFavoriteByUserEntityIdUseCase.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/domain/usecase/UpdateFavoriteByUserEntityIdUseCase.kt
@@ -1,0 +1,14 @@
+package com.gyleedev.chatchat.domain.usecase
+
+import com.gyleedev.chatchat.data.repository.UserRepository
+import com.gyleedev.chatchat.domain.RelatedUserLocalData
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+class UpdateFavoriteByUserEntityIdUseCase @Inject constructor(
+    private val repository: UserRepository
+) {
+    suspend operator fun invoke(relatedUserLocalData: RelatedUserLocalData): Boolean {
+        return repository.updateUserAndFavorite(relatedUserLocalData).first()
+    }
+}

--- a/app/src/main/java/com/gyleedev/chatchat/ui/friendinfo/FriendInfoScreen.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/ui/friendinfo/FriendInfoScreen.kt
@@ -10,9 +10,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.StarOutline
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.MoreVert
@@ -56,6 +59,11 @@ fun FriendInfoScreen(
     viewModel: FriendInfoViewModel = hiltViewModel()
 ) {
     val friendData by viewModel.relatedUserLocalData.collectAsStateWithLifecycle()
+    val starColor = if (requireNotNull(friendData).favoriteState) {
+        Color.Yellow
+    } else {
+        Color.Transparent
+    }
 
     var dropdownMenuExpanded by rememberSaveable { mutableStateOf(false) }
 
@@ -73,6 +81,25 @@ fun FriendInfoScreen(
                     }
                 },
                 actions = {
+                    IconButton(
+                        onClick = { viewModel.updateFavorite() }
+                    ) {
+                        // default size 24dp
+                        Icon(
+                            imageVector = Icons.Default.StarOutline,
+                            contentDescription = null,
+                            tint = Color.Black
+                        )
+
+                        // adjust size 18dp
+                        Icon(
+                            imageVector = Icons.Default.Star,
+                            contentDescription = null,
+                            tint = starColor,
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+
                     IconButton(onClick = { dropdownMenuExpanded = true }) {
                         Icon(
                             imageVector = Icons.Outlined.MoreVert,


### PR DESCRIPTION
- 즐겨찾기 추가, 해제 구현
- FavoriteDao 함수 추가
- UserAndFavoriteDao 함수 추가
- UserAndFavoriteEntity
 - 확장함수 수정
 - Embedded의 entityColumn 수정
- UserRepository
 - favorite update 관련 로직 추가
 - favorite관련 캐싱 로직 추가
 - favorite 관련 sort 로직 추가
- GetRelatedUserAndFavoriteDataUseCase 추가
- UpdateFavoriteByUserEntityUseCase 추가
- FriendInfoViewModel
 - update관련 의존성, 함수 추가
 - RelatedUserLocalData를 가져올때 favorite 정보도 함께 가져올 수 있도록 수정
- FriendInfoScreen
 - 즐겨찾기 관련 UI 추가
- close #42 