### PR TITLE
Paging 강제 refresh 수정

### DIFF
--- a/app/src/main/java/com/gyleedev/chatchat/ui/friendlist/FriendListScreen.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/ui/friendlist/FriendListScreen.kt
@@ -77,7 +77,7 @@ fun FriendListScreen(
     modifier: Modifier = Modifier,
     viewModel: FriendListViewModel = hiltViewModel()
 ) {
-    val items = viewModel.items.collectAsLazyPagingItems()
+    val items = viewModel.updatedItem.collectAsLazyPagingItems()
 
     var openFriendDialog by remember { mutableStateOf(false) }
     var dialogRelatedUserLocalData by remember { mutableStateOf<RelatedUserLocalData?>(null) }


### PR DESCRIPTION
- Paging 내부 아이템이 변화했을 때 ui를 강제 refresh 하는 대신 update된 항목을 list로 관리해서 list에 있는 항목을 filter해서 ui에 보여준다.