### PR TITLE
블락된 유저와의 대화에서 메시지가 수신되지 않도록 수정

### DIFF
--- a/app/src/main/java/com/gyleedev/chatchat/domain/usecase/GetMessagesFromRemoteUseCase.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/domain/usecase/GetMessagesFromRemoteUseCase.kt
@@ -3,13 +3,14 @@ package com.gyleedev.chatchat.domain.usecase
 import com.gyleedev.chatchat.data.repository.MessageRepository
 import com.gyleedev.chatchat.domain.ChatRoomLocalData
 import com.gyleedev.chatchat.domain.MessageData
+import com.gyleedev.chatchat.domain.UserRelationState
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class GetMessagesFromRemoteUseCase @Inject constructor(
     private val repository: MessageRepository
 ) {
-    operator fun invoke(chatRoom: ChatRoomLocalData): Flow<MessageData?> {
-        return repository.getMessageListener(chatRoom)
+    operator fun invoke(chatRoom: ChatRoomLocalData, userRelationState: UserRelationState): Flow<MessageData?> {
+        return repository.getMessageListener(chatRoom, userRelationState)
     }
 }

--- a/app/src/main/java/com/gyleedev/chatchat/ui/chatroom/ChatRoomScreen.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/ui/chatroom/ChatRoomScreen.kt
@@ -66,8 +66,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -107,6 +107,7 @@ fun ChatRoomScreen(
     val query = rememberTextFieldState()
     val messages = chatRoomViewModel.messages.collectAsLazyPagingItems()
     val photoUri = chatRoomViewModel.photoUri.collectAsStateWithLifecycle()
+    chatRoomViewModel.messagesCallback.collectAsStateWithLifecycle()
 
     val lazyListState = remember {
         mutableStateOf(
@@ -119,8 +120,7 @@ fun ChatRoomScreen(
     val context = LocalContext.current
     val lifecycle = LocalLifecycleOwner.current
 
-    val configuration = LocalConfiguration.current
-    val screenWidth = configuration.screenWidthDp
+    val screenWidth = LocalWindowInfo.current.containerSize.width
 
     val pickMedia =
         rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->


### PR DESCRIPTION
- MessageRepository
- 리스너 관련 수정
- 릴레이션이 블락일 때 메시지가 인서트되지 않도록 수정
- useCase를 repository의 수정사항에 맞춰서 수정
- ChatRoomViewModel
- init에서 collect 하는 코드 제거
- messageCallback을 만들어서 ui에서 구독하도록 함
- ChatRoomScreen
- screenWidth 가 LocalWindowInfo 를 통해 받도록 변경
- messageCallback을 ui에서 구돌하도록 수정
- close #76 
- close #63