### PR TITLE
delete message

### DIFF
--- a/app/src/main/java/com/gyleedev/chatchat/data/database/dao/MessageDao.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/data/database/dao/MessageDao.kt
@@ -27,7 +27,7 @@ interface MessageDao {
     fun getMessage(rid: String, time: Long, writer: String): Flow<MessageEntity>
 
     @Query("DELETE FROM message WHERE id = :messageId")
-    fun deleteMessage(messageId: Long)
+    suspend fun deleteMessage(messageId: Long)
 
     @Query("DELETE FROM message")
     suspend fun resetMessageDatabase()

--- a/app/src/main/java/com/gyleedev/chatchat/domain/usecase/DeleteMessageFromLocalUseCase.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/domain/usecase/DeleteMessageFromLocalUseCase.kt
@@ -7,5 +7,5 @@ class DeleteMessageFromLocalUseCase @Inject constructor(
     private val repository: MessageRepository
 ) {
     suspend operator fun invoke(messageId: Long) =
-        repository.deleteMessage(messageId)
+        repository.deleteLocalMessage(messageId)
 }

--- a/app/src/main/java/com/gyleedev/chatchat/domain/usecase/DeleteMessageUseCase.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/domain/usecase/DeleteMessageUseCase.kt
@@ -1,0 +1,12 @@
+package com.gyleedev.chatchat.domain.usecase
+
+import com.gyleedev.chatchat.data.repository.MessageRepository
+import com.gyleedev.chatchat.domain.MessageData
+import javax.inject.Inject
+
+class DeleteMessageUseCase @Inject constructor(
+    private val repository: MessageRepository
+) {
+    suspend operator fun invoke(messageData: MessageData) =
+        repository.deleteMessageRequest(messageData)
+}

--- a/app/src/main/java/com/gyleedev/chatchat/ui/chatroom/ChatRoomScreen.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/ui/chatroom/ChatRoomScreen.kt
@@ -9,6 +9,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -23,6 +24,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.shape.CircleShape
@@ -43,6 +45,8 @@ import androidx.compose.material.icons.outlined.PersonAddAlt
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.RemoveCircleOutline
 import androidx.compose.material.icons.outlined.ReportProblem
+import androidx.compose.material3.AlertDialogDefaults
+import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -108,6 +112,7 @@ fun ChatRoomScreen(
     val messages = chatRoomViewModel.messages.collectAsLazyPagingItems()
     val photoUri = chatRoomViewModel.photoUri.collectAsStateWithLifecycle()
     chatRoomViewModel.messagesCallback.collectAsStateWithLifecycle()
+    var openMessageDialog by remember { mutableStateOf(false) }
 
     val lazyListState = remember {
         mutableStateOf(
@@ -220,7 +225,8 @@ fun ChatRoomScreen(
                                         me = (uiState as ChatRoomUiState.Success).uid,
                                         messageData = messageData,
                                         resend = { chatRoomViewModel.resendMessage(messageData) },
-                                        cancel = { chatRoomViewModel.cancelMessage(messageData) }
+                                        cancel = { chatRoomViewModel.cancelMessage(messageData) },
+                                        onLongClick = { openMessageDialog = true }
                                     )
                                 }
 
@@ -249,6 +255,13 @@ fun ChatRoomScreen(
                 }
             }
         }
+
+        if (openMessageDialog) {
+            MessageDialog(
+                "",
+                closeDialog = { openMessageDialog = false }
+            )
+        }
     }
 }
 
@@ -256,6 +269,7 @@ fun ChatRoomScreen(
 fun ChatBubble(
     resend: () -> Unit,
     cancel: () -> Unit,
+    onLongClick: () -> Unit,
     me: String,
     messageData: MessageData,
     modifier: Modifier = Modifier
@@ -287,7 +301,11 @@ fun ChatBubble(
         }
         Surface(
             color = backgroundColor,
-            shape = backgroundShape
+            shape = backgroundShape,
+            modifier = Modifier.combinedClickable(
+                onLongClick = onLongClick,
+                onClick = {}
+            )
         ) {
             Text(text = messageData.comment, modifier = Modifier.padding(16.dp))
         }
@@ -797,4 +815,75 @@ fun ResendButtonPreview() {
     ChatChatTheme {
         ResendButton(onResendClick = {}, onCancelClick = {})
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MessageDialog(
+    name: String,
+    closeDialog: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    BasicAlertDialog(
+        onDismissRequest = closeDialog,
+        content = {
+            Surface(
+                modifier = Modifier.wrapContentSize(),
+                shape = MaterialTheme.shapes.medium,
+                tonalElevation = AlertDialogDefaults.TonalElevation,
+                color = AlertDialogDefaults.containerColor
+            ) {
+                Column(
+                    modifier = Modifier.padding(vertical = 24.dp),
+                    horizontalAlignment = Alignment.Start
+                ) {
+                    Text(
+                        text = name,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.padding(horizontal = 24.dp)
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = stringResource(R.string.add_favorite_button_text),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                closeDialog()
+                            }
+                            .padding(horizontal = 24.dp, vertical = 8.dp)
+                    )
+                    Text(
+                        text = stringResource(R.string.friend_block_button_text),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                closeDialog()
+                            }
+                            .padding(horizontal = 24.dp, vertical = 8.dp)
+                    )
+
+                    Text(
+                        text = stringResource(R.string.friend_delete_button_text),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                closeDialog()
+                            }
+                            .padding(horizontal = 24.dp, vertical = 8.dp)
+                    )
+                    Text(
+                        text = stringResource(R.string.friend_hide_button_text),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                closeDialog()
+                            }
+                            .padding(horizontal = 24.dp, vertical = 8.dp)
+                    )
+                }
+            }
+        },
+        modifier = modifier.wrapContentSize()
+    )
 }

--- a/app/src/main/java/com/gyleedev/chatchat/ui/chatroom/ChatRoomScreen.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/ui/chatroom/ChatRoomScreen.kt
@@ -258,8 +258,11 @@ fun ChatRoomScreen(
 
         if (openMessageDialog) {
             MessageDialog(
-                "",
-                closeDialog = { openMessageDialog = false }
+                closeDialog = { openMessageDialog = false },
+                onCopy = {},
+                onPartialCopy = {},
+                onReply = {},
+                onDelete = {}
             )
         }
     }
@@ -820,7 +823,10 @@ fun ResendButtonPreview() {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MessageDialog(
-    name: String,
+    onCopy: () -> Unit,
+    onPartialCopy: () -> Unit,
+    onReply: () -> Unit,
+    onDelete: () -> Unit,
     closeDialog: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -838,45 +844,42 @@ fun MessageDialog(
                     horizontalAlignment = Alignment.Start
                 ) {
                     Text(
-                        text = name,
-                        style = MaterialTheme.typography.titleLarge,
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier.padding(horizontal = 24.dp)
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        text = stringResource(R.string.add_favorite_button_text),
+                        text = stringResource(R.string.chat_room_dialog_copy_text),
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable {
-                                closeDialog()
-                            }
-                            .padding(horizontal = 24.dp, vertical = 8.dp)
-                    )
-                    Text(
-                        text = stringResource(R.string.friend_block_button_text),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable {
+                                onCopy()
                                 closeDialog()
                             }
                             .padding(horizontal = 24.dp, vertical = 8.dp)
                     )
 
                     Text(
-                        text = stringResource(R.string.friend_delete_button_text),
+                        text = stringResource(R.string.chat_room_dialog_copy_partial_text),
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable {
+                                onPartialCopy()
                                 closeDialog()
                             }
                             .padding(horizontal = 24.dp, vertical = 8.dp)
                     )
                     Text(
-                        text = stringResource(R.string.friend_hide_button_text),
+                        text = stringResource(R.string.chat_room_dialog_reply_text),
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable {
+                                onReply()
+                                closeDialog()
+                            }
+                            .padding(horizontal = 24.dp, vertical = 8.dp)
+                    )
+                    Text(
+                        text = stringResource(R.string.chat_room_dialog_delete_text),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                onDelete()
                                 closeDialog()
                             }
                             .padding(horizontal = 24.dp, vertical = 8.dp)

--- a/app/src/main/java/com/gyleedev/chatchat/ui/chatroom/ChatRoomScreen.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/ui/chatroom/ChatRoomScreen.kt
@@ -113,6 +113,7 @@ fun ChatRoomScreen(
     val photoUri = chatRoomViewModel.photoUri.collectAsStateWithLifecycle()
     chatRoomViewModel.messagesCallback.collectAsStateWithLifecycle()
     var openMessageDialog by remember { mutableStateOf(false) }
+    var dialogMessageData by remember { mutableStateOf<MessageData?>(null) }
 
     val lazyListState = remember {
         mutableStateOf(
@@ -226,7 +227,10 @@ fun ChatRoomScreen(
                                         messageData = messageData,
                                         resend = { chatRoomViewModel.resendMessage(messageData) },
                                         cancel = { chatRoomViewModel.cancelMessage(messageData) },
-                                        onLongClick = { openMessageDialog = true }
+                                        onLongClick = {
+                                            dialogMessageData = messageData
+                                            openMessageDialog = true
+                                        }
                                     )
                                 }
 
@@ -258,11 +262,18 @@ fun ChatRoomScreen(
 
         if (openMessageDialog) {
             MessageDialog(
-                closeDialog = { openMessageDialog = false },
-                onCopy = {},
-                onPartialCopy = {},
-                onReply = {},
-                onDelete = {}
+                closeDialog = {
+                    dialogMessageData = null
+                    openMessageDialog = false
+                },
+                onCopy = { },
+                onPartialCopy = { },
+                onReply = { },
+                onDelete = {
+                    dialogMessageData?.let {
+                        chatRoomViewModel.deleteMessage(it)
+                    }
+                }
             )
         }
     }

--- a/app/src/main/java/com/gyleedev/chatchat/ui/chatroom/ChatRoomViewModel.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/ui/chatroom/ChatRoomViewModel.kt
@@ -17,6 +17,7 @@ import com.gyleedev.chatchat.domain.RelatedUserLocalData
 import com.gyleedev.chatchat.domain.UserRelationState
 import com.gyleedev.chatchat.domain.usecase.BlockRelatedUserUseCase
 import com.gyleedev.chatchat.domain.usecase.CancelMessageUseCase
+import com.gyleedev.chatchat.domain.usecase.DeleteMessageUseCase
 import com.gyleedev.chatchat.domain.usecase.GetChatRoomDataUseCase
 import com.gyleedev.chatchat.domain.usecase.GetChatRoomLocalDataByUidUseCase
 import com.gyleedev.chatchat.domain.usecase.GetFriendDataUseCase
@@ -58,6 +59,7 @@ class ChatRoomViewModel @Inject constructor(
     private val cancelMessageUseCase: CancelMessageUseCase,
     private val userToFriendUseCase: UserToFriendUseCase,
     private val blockRelatedUserUseCase: BlockRelatedUserUseCase,
+    private val deleteMessageUseCase: DeleteMessageUseCase,
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel() {
     private val relatedUserLocalData = MutableStateFlow(RelatedUserLocalData())
@@ -230,6 +232,12 @@ class ChatRoomViewModel @Inject constructor(
                 userRelation = UserRelationState.FRIEND
             )
             relatedUserLocalData.emit(changedData)
+        }
+    }
+
+    fun deleteMessage(messageData: MessageData) {
+        viewModelScope.launch {
+            val request = deleteMessageUseCase(messageData).first()
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,4 +103,8 @@
     <string name="chat_room_not_friend_text_up">친구가 아닌 사용자입니다.</string>
     <string name="chat_room_not_friend_text_down">의심스러운 사용자인 경우 차단하고 신고해 주세요.</string>
     <string name="chat_room_blocked_user_bottom_bar_text">차단된 유저입니다.</string>
+    <string name="chat_room_dialog_copy_text">복사</string>
+    <string name="chat_room_dialog_copy_partial_text">선택 복사</string>
+    <string name="chat_room_dialog_reply_text">답장</string>
+    <string name="chat_room_dialog_delete_text">삭제</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,10 @@
     <string name="logout_dialog_message">로그아웃 하시겠습니까?</string>
     <string name="dialog_dismiss_button_text">취소</string>
     <string name="dialog_confirm_button_text">확인</string>
+    <string name="dialog_delete_button_text">삭제</string>
+    <string name="delete_message_dialog_text">현재 사용중인 기기에서만 삭제되며 상대방의 채팅방에서는 삭제되지 않습니다.</string>
+    <string name="delete_message_dialog_my_message_header">내 메시지 삭제</string>
+    <string name="delete_message_dialog_other_message_header">다른 유저의 메시지 삭제</string>
     <string name="signin_screen_title">회원 가입</string>
     <string name="signin_button_title">회원 가입</string>
     <string name="unblock_icon_description">차단 해제 아이콘</string>


### PR DESCRIPTION
- 메시지 삭제 기능 구현
- 메시지 롱클릭으로  메시지 다이얼로그 열도록 구현
- 메시지 다이얼로그 삭제 버튼 클릭 시 삭제 다이얼로그 열도록 구현
- 삭제 다이얼로그에서 삭제 버튼 클릭시 메시지 삭제
- 내 메시지는 remote에도 삭제 다른사람의 메시지는 로컬에서만 삭제하도록 구현
- 챗버블에 롱클릭 관련 추가
- close #108 