### PR TITLE
Chore(build-logic, app) 디펜던시 버전 업데이트 및 firebase bom 일원화

### DIFF
--- a/app/src/main/java/com/gyleedev/chatchat/di/FirebaseModule.kt
+++ b/app/src/main/java/com/gyleedev/chatchat/di/FirebaseModule.kt
@@ -1,8 +1,8 @@
 package com.gyleedev.chatchat.di
 
+import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.FirebaseDatabase
-import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.FirebaseStorage
 import dagger.Module
 import dagger.Provides

--- a/build-logic/src/main/java/com/gyleedev/buildlogic/FirebaseAndroid.kt
+++ b/build-logic/src/main/java/com/gyleedev/buildlogic/FirebaseAndroid.kt
@@ -15,10 +15,9 @@ internal fun Project.configureFirebaseAndroidLibrary() {
     val libs = extensions.libs
     androidExtension.apply {
         dependencies {
-            val bom = libs.findLibrary("firebase.bom").get()
+            val bom = libs.findLibrary("firebase-bom").get()
             add("implementation", platform(bom))
-            add("implementation", libs.findLibrary("firebase.bom").get())
-            add("implementation", libs.findLibrary("firebase.analystics").get())
+            add("implementation", libs.findLibrary("firebase.analytics").get())
             add("implementation", libs.findLibrary("firebase.crashlytics").get())
             add("implementation", libs.findLibrary("firebase.auth").get())
             add("implementation", libs.findLibrary("firebase.services.auth").get())

--- a/build-logic/src/main/java/com/gyleedev/buildlogic/KotlinAndroid.kt
+++ b/build-logic/src/main/java/com/gyleedev/buildlogic/KotlinAndroid.kt
@@ -38,7 +38,7 @@ internal fun Project.configureKotlinAndroid() {
 internal fun Project.configureGradleScript() {
 
     androidExtension.apply {
-        compileSdk = 35
+        compileSdk = 36
 
         defaultConfig {
             minSdk = 24

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import com.diffplug.gradle.spotless.SpotlessExtension
 buildscript {
     repositories {
         google()
+        mavenCentral()
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,35 +1,35 @@
 [versions]
-agp = "8.11.0"
-kotlin = "2.1.21"
-coreKtx = "1.16.0"
+agp = "8.12.2"
+kotlin = "2.2.10"
+coreKtx = "1.17.0"
 junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.9.1"
+junitVersion = "1.3.0"
+espressoCore = "3.7.0"
+lifecycleRuntimeKtx = "2.9.3"
 activityCompose = "1.10.1"
-composeBom = "2025.06.01"
-mockkAndroid = "1.14.4"
-spotless = "6.11.0"
+composeBom = "2025.08.01"
+mockkAndroid = "1.14.5"
+spotless = "7.2.1"
 firebase = "4.4.3"
-firebaseBom = "33.16.0"
-firebaseAuth = "23.2.1"
-playServicesAuth = "21.3.0"
-ksp = "2.1.21-2.0.1"
-hilt = "2.56.2"
+firebaseBom = "34.2.0"
+firebaseAuth = "24.0.1"
+playServicesAuth = "21.4.0"
+ksp = "2.2.10-2.0.2"
+hilt = "2.57.1"
 hiltNavCompose = "1.2.0"
-google-gson = "2.11.0"
+google-gson = "2.13.1"
 room = "2.7.2"
 splash = "1.0.1"
-landscapist = "2.4.6"
+landscapist = "2.5.2"
 paging = "3.3.6"
-crashlytics = "3.0.4"
-jsoup = "1.18.3"
+crashlytics = "3.0.6"
+jsoup = "1.21.2"
 appcompat = "1.7.1"
-material = "1.12.0"
-jetbrainsKotlinJvm = "2.1.21"
-androidTools = "31.11.0"
+material = "1.13.0"
+jetbrainsKotlinJvm = "2.2.10"
+androidTools = "31.13.0"
 coroutine = "1.10.2"
-browser = "1.8.0"
+browser = "1.9.0"
 
 [libraries]
 
@@ -39,7 +39,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
-androidx-browser = { group = "androidx.browser", name = "browser" }
+androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
 
 ##UI
 ##Compose
@@ -77,12 +77,12 @@ paging-compose = { module = "androidx.paging:paging-compose", version.ref = "pag
 
 ##Firebase
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
-firebase-analystics = { group = "com.google.firebase", name = "firebase-analytics" }
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
-firebase-auth = { group = "com.google.firebase", name = "firebase-auth", version.ref = "firebaseAuth" }
+firebase-auth = { group = "com.google.firebase", name = "firebase-auth" }
 firebase-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = 'playServicesAuth' }
 firebase-database = { group = "com.google.firebase", name = "firebase-database" }
-firebase-storage = { group = "com.google.firebase", name = "firebase-storage-ktx" }
+firebase-storage = { group = "com.google.firebase", name = "firebase-storage" }
 firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 
 ##Hilt


### PR DESCRIPTION
  - build-logic(FirebaseAndroid): BOM을 platform으로만 적용, 중복 제거; firebase.analytics alias 정정; firebase-bom 키로 참조 일관화
  - build-logic(KotlinAndroid): compileSdk 36으로 상향
  - app(FirebaseModule): com.google.firebase.Firebase import로 정리(ktx 혼선 제거)
  - versions(catalog): Kotlin/AGP/AndroidX/Compose/Firebase/Crashlytics/browser 등 버전 정리, firebase-storage-ktx 명시 버전 추가
  - root build.gradle.kts: 버전 카탈로그/플러그인 참조 업데이트에 맞춰 스크립트 정리