### PR TITLE
a~d 로 시작하는 유스케이스 중에 단일 함수를 호출하는 유스케이스의 테스트를 구현

### DIFF
--- a/data/src/main/java/com/gyleedev/data/repository/MessageRepositoryImpl.kt
+++ b/data/src/main/java/com/gyleedev/data/repository/MessageRepositoryImpl.kt
@@ -112,12 +112,12 @@ class MessageRepositoryImpl @Inject constructor(
                         previousChildName: String?,
                     ) {
                         trySend(null)
-                            /*for (ds in snapshot.getChildren()) {
-                                val snap = ds.getValue(MessageData::class.java)
-                                if (snap != null) {
-                                    insertMessage(snap, chatRoom.id)
-                                }
-                            }*/
+                        /*for (ds in snapshot.getChildren()) {
+                            val snap = ds.getValue(MessageData::class.java)
+                            if (snap != null) {
+                                insertMessage(snap, chatRoom.id)
+                            }
+                        }*/
                     }
 
                     override fun onChildRemoved(snapshot: DataSnapshot) {

--- a/data/src/main/java/com/gyleedev/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/gyleedev/data/repository/UserRepositoryImpl.kt
@@ -907,6 +907,7 @@ class UserRepositoryImpl @Inject constructor(
         awaitClose()
     }
 
+    // reload 를 해야 currentUser 가 업데이트 됨
     override fun checkUserVerified(): Flow<Boolean> = callbackFlow {
         requireNotNull(auth.currentUser).reload().addOnCompleteListener { task ->
             if (task.isSuccessful) {

--- a/domain/src/main/java/com/gyleedev/domain/usecase/AddFriendRequestUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/domain/usecase/AddFriendRequestUseCase.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -16,9 +15,9 @@ class AddFriendRequestUseCase @Inject constructor(
 ) {
     operator fun invoke(userData: UserData): Flow<Boolean> = callbackFlow {
         withContext(Dispatchers.IO) {
-            val remoteRequest = addFriendToRemoteUseCase(userData).first()
+            val remoteRequest = addFriendToRemoteUseCase(userData)
             if (remoteRequest) {
-                val localRequest = addFriendToLocalUseCase(userData).first()
+                val localRequest = addFriendToLocalUseCase(userData)
                 if (localRequest) {
                     trySend(true)
                 } else {

--- a/domain/src/main/java/com/gyleedev/domain/usecase/AddFriendToLocalUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/domain/usecase/AddFriendToLocalUseCase.kt
@@ -3,10 +3,13 @@ package com.gyleedev.domain.usecase
 import com.gyleedev.domain.model.UserData
 import com.gyleedev.domain.repository.UserRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class AddFriendToLocalUseCase @Inject constructor(
     private val repository: UserRepository,
 ) {
-    suspend operator fun invoke(userData: UserData): Flow<Boolean> = repository.insertFriendToLocal(userData)
+    suspend operator fun invoke(userData: UserData): Boolean {
+        return repository.insertFriendToLocal(userData).first()
+    }
 }

--- a/domain/src/main/java/com/gyleedev/domain/usecase/AddFriendToLocalUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/domain/usecase/AddFriendToLocalUseCase.kt
@@ -2,14 +2,11 @@ package com.gyleedev.domain.usecase
 
 import com.gyleedev.domain.model.UserData
 import com.gyleedev.domain.repository.UserRepository
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class AddFriendToLocalUseCase @Inject constructor(
     private val repository: UserRepository,
 ) {
-    suspend operator fun invoke(userData: UserData): Boolean {
-        return repository.insertFriendToLocal(userData).first()
-    }
+    suspend operator fun invoke(userData: UserData): Boolean = repository.insertFriendToLocal(userData).first()
 }

--- a/domain/src/main/java/com/gyleedev/domain/usecase/AddFriendToRemoteUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/domain/usecase/AddFriendToRemoteUseCase.kt
@@ -2,14 +2,11 @@ package com.gyleedev.domain.usecase
 
 import com.gyleedev.domain.model.UserData
 import com.gyleedev.domain.repository.UserRepository
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class AddFriendToRemoteUseCase @Inject constructor(
     private val repository: UserRepository,
 ) {
-    suspend operator fun invoke(userData: UserData): Boolean {
-        return repository.addRelatedUserToRemote(userData).first()
-    }
+    suspend operator fun invoke(userData: UserData): Boolean = repository.addRelatedUserToRemote(userData).first()
 }

--- a/domain/src/main/java/com/gyleedev/domain/usecase/AddFriendToRemoteUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/domain/usecase/AddFriendToRemoteUseCase.kt
@@ -3,10 +3,13 @@ package com.gyleedev.domain.usecase
 import com.gyleedev.domain.model.UserData
 import com.gyleedev.domain.repository.UserRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class AddFriendToRemoteUseCase @Inject constructor(
     private val repository: UserRepository,
 ) {
-    suspend operator fun invoke(userData: UserData): Flow<Boolean> = repository.addRelatedUserToRemote(userData)
+    suspend operator fun invoke(userData: UserData): Boolean {
+        return repository.addRelatedUserToRemote(userData).first()
+    }
 }

--- a/domain/src/main/java/com/gyleedev/domain/usecase/AddMyRelatedUsersUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/domain/usecase/AddMyRelatedUsersUseCase.kt
@@ -9,7 +9,9 @@ import javax.inject.Inject
 class AddMyRelatedUsersUseCase @Inject constructor(
     private val repository: UserRepository,
 ) {
-    suspend operator fun invoke(friends: List<RelatedUserRemoteData>) = withContext(Dispatchers.IO) {
-        repository.insertMyRelationsToLocal(friends)
+    suspend operator fun invoke(friends: List<RelatedUserRemoteData>) {
+        withContext(Dispatchers.IO) {
+            repository.insertMyRelationsToLocal(friends)
+        }
     }
 }

--- a/domain/src/main/java/com/gyleedev/domain/usecase/BlockUnknownUserUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/domain/usecase/BlockUnknownUserUseCase.kt
@@ -8,7 +8,5 @@ import javax.inject.Inject
 class BlockUnknownUserUseCase @Inject constructor(
     private val repository: UserRepository,
 ) {
-    suspend operator fun invoke(userData: UserData): ChangeRelationResult {
-        return repository.blockUnknownUserRequest(userData)
-    }
+    suspend operator fun invoke(userData: UserData): ChangeRelationResult = repository.blockUnknownUserRequest(userData)
 }

--- a/domain/src/main/java/com/gyleedev/domain/usecase/BlockUnknownUserUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/domain/usecase/BlockUnknownUserUseCase.kt
@@ -1,5 +1,6 @@
 package com.gyleedev.domain.usecase
 
+import com.gyleedev.domain.model.ChangeRelationResult
 import com.gyleedev.domain.model.UserData
 import com.gyleedev.domain.repository.UserRepository
 import javax.inject.Inject
@@ -7,5 +8,7 @@ import javax.inject.Inject
 class BlockUnknownUserUseCase @Inject constructor(
     private val repository: UserRepository,
 ) {
-    suspend operator fun invoke(userData: UserData) = repository.blockUnknownUserRequest(userData)
+    suspend operator fun invoke(userData: UserData): ChangeRelationResult {
+        return repository.blockUnknownUserRequest(userData)
+    }
 }

--- a/domain/src/main/java/com/gyleedev/domain/usecase/CancelSigninUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/domain/usecase/CancelSigninUseCase.kt
@@ -6,5 +6,7 @@ import javax.inject.Inject
 class CancelSigninUseCase @Inject constructor(
     private val repository: UserRepository,
 ) {
-    suspend operator fun invoke() = repository.cancelSigninRequest()
+    suspend operator fun invoke(): Boolean {
+        return repository.cancelSigninRequest()
+    }
 }

--- a/domain/src/main/java/com/gyleedev/domain/usecase/CancelSigninUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/domain/usecase/CancelSigninUseCase.kt
@@ -6,7 +6,5 @@ import javax.inject.Inject
 class CancelSigninUseCase @Inject constructor(
     private val repository: UserRepository,
 ) {
-    suspend operator fun invoke(): Boolean {
-        return repository.cancelSigninRequest()
-    }
+    suspend operator fun invoke(): Boolean = repository.cancelSigninRequest()
 }

--- a/domain/src/main/java/com/gyleedev/domain/usecase/CheckVerifiedUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/domain/usecase/CheckVerifiedUseCase.kt
@@ -7,5 +7,7 @@ import javax.inject.Inject
 class CheckVerifiedUseCase @Inject constructor(
     private val repository: UserRepository,
 ) {
-    suspend operator fun invoke(): Boolean = repository.checkUserVerified().first()
+    suspend operator fun invoke(): Boolean {
+        return repository.checkUserVerified().first()
+    }
 }

--- a/domain/src/main/java/com/gyleedev/domain/usecase/CheckVerifiedUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/domain/usecase/CheckVerifiedUseCase.kt
@@ -7,7 +7,5 @@ import javax.inject.Inject
 class CheckVerifiedUseCase @Inject constructor(
     private val repository: UserRepository,
 ) {
-    suspend operator fun invoke(): Boolean {
-        return repository.checkUserVerified().first()
-    }
+    suspend operator fun invoke(): Boolean = repository.checkUserVerified().first()
 }

--- a/domain/src/main/java/com/gyleedev/domain/usecase/DeleteFriendUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/domain/usecase/DeleteFriendUseCase.kt
@@ -1,5 +1,6 @@
 package com.gyleedev.domain.usecase
 
+import com.gyleedev.domain.model.ChangeRelationResult
 import com.gyleedev.domain.model.RelatedUserLocalData
 import com.gyleedev.domain.repository.UserRepository
 import javax.inject.Inject
@@ -7,5 +8,5 @@ import javax.inject.Inject
 class DeleteFriendUseCase @Inject constructor(
     private val repository: UserRepository,
 ) {
-    suspend operator fun invoke(friend: RelatedUserLocalData) = repository.deleteFriendRequest(friend)
+    suspend operator fun invoke(friend: RelatedUserLocalData): ChangeRelationResult = repository.deleteFriendRequest(friend)
 }

--- a/domain/src/main/java/com/gyleedev/domain/usecase/DeleteMessageUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/domain/usecase/DeleteMessageUseCase.kt
@@ -1,11 +1,13 @@
 package com.gyleedev.domain.usecase
 
 import com.gyleedev.domain.model.MessageData
+import com.gyleedev.domain.model.ProcessResult
 import com.gyleedev.domain.repository.MessageRepository
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class DeleteMessageUseCase @Inject constructor(
     private val repository: MessageRepository,
 ) {
-    suspend operator fun invoke(messageData: MessageData) = repository.deleteMessageRequest(messageData)
+    suspend operator fun invoke(messageData: MessageData): ProcessResult = repository.deleteMessageRequest(messageData).first()
 }

--- a/domain/src/test/java/com/gyleedev/domain/usecase/AddFriendToLocalUseCaseTest.kt
+++ b/domain/src/test/java/com/gyleedev/domain/usecase/AddFriendToLocalUseCaseTest.kt
@@ -1,0 +1,58 @@
+package com.gyleedev.domain.usecase
+
+import com.gyleedev.domain.model.UserData
+import com.gyleedev.domain.repository.UserRepository
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class AddFriendToLocalUseCaseTest {
+
+    private lateinit var useCase: AddFriendToLocalUseCase
+
+    @MockK
+    lateinit var repository: UserRepository
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        useCase = AddFriendToLocalUseCase(repository)
+    }
+
+    @Test
+    fun `로컬_친구_추가_성공`() = runTest {
+        val user = UserData(uid = "uid")
+        val result = flowOf(true)
+        coEvery { repository.insertFriendToLocal(user) } returns result
+
+        val answer = useCase(user)
+
+        assertEquals(answer, result.first())
+
+        coVerify(exactly = 1) {
+            repository.insertFriendToLocal(user)
+        }
+    }
+
+    @Test
+    fun `로컬_친구_추가_실패`() = runTest {
+        val user = UserData(uid = "uid")
+        val result = flowOf(false)
+        coEvery { repository.insertFriendToLocal(user) } returns result
+
+        val answer = useCase(user)
+
+        assertEquals(answer, result.first())
+
+        coVerify(exactly = 1) {
+            repository.insertFriendToLocal(user)
+        }
+    }
+}

--- a/domain/src/test/java/com/gyleedev/domain/usecase/AddFriendToRemoteUseCaseTest.kt
+++ b/domain/src/test/java/com/gyleedev/domain/usecase/AddFriendToRemoteUseCaseTest.kt
@@ -1,0 +1,80 @@
+package com.gyleedev.domain.usecase
+
+import com.gyleedev.domain.model.UserData
+import com.gyleedev.domain.repository.UserRepository
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class AddFriendToRemoteUseCaseTest {
+
+    private lateinit var useCase: AddFriendToRemoteUseCase
+
+    @MockK
+    lateinit var repository: UserRepository
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        useCase = AddFriendToRemoteUseCase(repository)
+    }
+
+    @Test
+    fun `원격_친구_추가_성공`() = runTest {
+        val user = UserData(uid = "uid")
+        val result = flowOf(true)
+        coEvery { repository.addRelatedUserToRemote(user) } returns result
+
+        val answer = useCase(user)
+
+        assertEquals(result.first(), answer)
+
+        coVerify(exactly = 1) {
+            repository.addRelatedUserToRemote(user)
+        }
+    }
+
+    @Test
+    fun `원격_친구_추가_실패`() = runTest {
+        val user = UserData(uid = "uid")
+        val result = flowOf(false)
+        coEvery { repository.addRelatedUserToRemote(user) } returns result
+
+        val answer = useCase(user)
+
+        assertEquals(result.first(), answer)
+
+        coVerify(exactly = 1) {
+            repository.addRelatedUserToRemote(user)
+        }
+    }
+
+    @Test
+    fun `원격_친구_추가_예외`() = runTest {
+        val user = UserData(uid = "uid")
+        val error = RuntimeException("error")
+        coEvery { repository.addRelatedUserToRemote(user) } throws error
+
+        var thrown = false
+
+        try {
+            useCase(user)
+        } catch (e: Throwable) {
+            thrown = true
+            assertEquals(error.message, e.message)
+        }
+
+        assertEquals(true, thrown)
+
+        coVerify(exactly = 1) {
+            repository.addRelatedUserToRemote(user)
+        }
+    }
+}

--- a/domain/src/test/java/com/gyleedev/domain/usecase/AddMyRelatedUsersUseCaseTest.kt
+++ b/domain/src/test/java/com/gyleedev/domain/usecase/AddMyRelatedUsersUseCaseTest.kt
@@ -1,0 +1,63 @@
+package com.gyleedev.domain.usecase
+
+import com.gyleedev.domain.model.RelatedUserRemoteData
+import com.gyleedev.domain.repository.UserRepository
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+// Refactor
+// 리턴타입이 Unit인데 실패시에 처리가 없음
+// 더 상단(ViewModel 단에서 구조변경을 고민해야함
+class AddMyRelatedUsersUseCaseTest {
+
+    private lateinit var useCase: AddMyRelatedUsersUseCase
+
+    @MockK
+    lateinit var repository: UserRepository
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        useCase = AddMyRelatedUsersUseCase(repository)
+    }
+
+    @Test
+    fun `릴레이션_로컬_삽입_성공`() = runTest {
+        val friends = listOf(RelatedUserRemoteData(uid = "uid"))
+        coEvery { repository.insertMyRelationsToLocal(friends) } returns Unit
+
+        useCase(friends)
+
+        coVerify(exactly = 1) {
+            repository.insertMyRelationsToLocal(friends)
+        }
+    }
+
+    @Test
+    fun `릴레이션_로컬_삽입_예외`() = runTest {
+        val friends = listOf(RelatedUserRemoteData(uid = "uid"))
+        val error = RuntimeException("error")
+        coEvery { repository.insertMyRelationsToLocal(friends) } throws error
+
+        var thrown = false
+
+        try {
+            useCase(friends)
+        } catch (e: Throwable) {
+            thrown = true
+            assertEquals(error.message, e.message)
+        }
+
+        assertEquals(true, thrown)
+
+        coVerify(exactly = 1) {
+            repository.insertMyRelationsToLocal(friends)
+        }
+    }
+}

--- a/domain/src/test/java/com/gyleedev/domain/usecase/BlockUnknownUserUseCaseTest.kt
+++ b/domain/src/test/java/com/gyleedev/domain/usecase/BlockUnknownUserUseCaseTest.kt
@@ -1,0 +1,79 @@
+package com.gyleedev.domain.usecase
+
+import com.gyleedev.domain.model.ChangeRelationResult
+import com.gyleedev.domain.model.UserData
+import com.gyleedev.domain.repository.UserRepository
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class BlockUnknownUserUseCaseTest {
+
+    private lateinit var useCase: BlockUnknownUserUseCase
+
+    @MockK
+    lateinit var repository: UserRepository
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        useCase = BlockUnknownUserUseCase(repository)
+    }
+
+    @Test
+    fun `알수없는_사용자_차단_성공`() = runTest {
+        val userData = UserData(uid = "unknown")
+        val result = ChangeRelationResult.SUCCESS
+        coEvery { repository.blockUnknownUserRequest(userData) } returns result
+
+        val answer = useCase(userData)
+
+        assertEquals(result, answer)
+
+        coVerify(exactly = 1) {
+            repository.blockUnknownUserRequest(userData)
+        }
+    }
+
+    @Test
+    fun `알수없는_사용자_차단_실패`() = runTest {
+        val userData = UserData(uid = "unknown")
+        val result = ChangeRelationResult.FAILURE
+        coEvery { repository.blockUnknownUserRequest(userData) } returns result
+
+        val answer = useCase(userData)
+
+        assertEquals(result, answer)
+
+        coVerify(exactly = 1) {
+            repository.blockUnknownUserRequest(userData)
+        }
+    }
+
+    @Test
+    fun `알수없는_사용자_차단_예외`() = runTest {
+        val userData = UserData(uid = "unknown")
+        val error = RuntimeException("error")
+        coEvery { repository.blockUnknownUserRequest(userData) } throws error
+
+        var thrown = false
+
+        try {
+            useCase(userData)
+        } catch (e: Throwable) {
+            thrown = true
+            assertEquals(error.message, e.message)
+        }
+
+        assertEquals(true, thrown)
+
+        coVerify(exactly = 1) {
+            repository.blockUnknownUserRequest(userData)
+        }
+    }
+}

--- a/domain/src/test/java/com/gyleedev/domain/usecase/CancelSigninUseCaseTest.kt
+++ b/domain/src/test/java/com/gyleedev/domain/usecase/CancelSigninUseCaseTest.kt
@@ -1,0 +1,74 @@
+package com.gyleedev.domain.usecase
+
+import com.gyleedev.domain.repository.UserRepository
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class CancelSigninUseCaseTest {
+
+    private lateinit var useCase: CancelSigninUseCase
+
+    @MockK
+    lateinit var repository: UserRepository
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        useCase = CancelSigninUseCase(repository)
+    }
+
+    @Test
+    fun `회원가입_취소_성공`() = runTest {
+        val result = true
+        coEvery { repository.cancelSigninRequest() } returns result
+
+        val answer = useCase()
+
+        assertEquals(result, answer)
+
+        coVerify(exactly = 1) {
+            repository.cancelSigninRequest()
+        }
+    }
+
+    @Test
+    fun `회원가입_취소_실패`() = runTest {
+        val result = false
+        coEvery { repository.cancelSigninRequest() } returns result
+
+        val answer = useCase()
+
+        assertEquals(result, answer)
+
+        coVerify(exactly = 1) {
+            repository.cancelSigninRequest()
+        }
+    }
+
+    @Test
+    fun `회원가입_취소_예외`() = runTest {
+        val error = RuntimeException("error")
+        coEvery { repository.cancelSigninRequest() } throws error
+
+        var thrown = false
+
+        try {
+            useCase()
+        } catch (e: Throwable) {
+            thrown = true
+            assertEquals(error.message, e.message)
+        }
+
+        assertEquals(true, thrown)
+
+        coVerify(exactly = 1) {
+            repository.cancelSigninRequest()
+        }
+    }
+}

--- a/domain/src/test/java/com/gyleedev/domain/usecase/CheckVerifiedUseCaseTest.kt
+++ b/domain/src/test/java/com/gyleedev/domain/usecase/CheckVerifiedUseCaseTest.kt
@@ -1,0 +1,64 @@
+package com.gyleedev.domain.usecase
+
+import com.gyleedev.domain.repository.UserRepository
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class CheckVerifiedUseCaseTest {
+
+    private lateinit var useCase: CheckVerifiedUseCase
+
+    @MockK
+    lateinit var repository: UserRepository
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        useCase = CheckVerifiedUseCase(repository)
+    }
+
+    @Test
+    fun `인증_여부_확인_성공`() {
+        val result = flowOf(true)
+        every { repository.checkUserVerified() } returns result
+        runTest {
+            val answer = useCase()
+
+            assertEquals(result.first(), answer)
+
+            verify(exactly = 1) {
+                repository.checkUserVerified()
+            }
+        }
+    }
+
+    @Test
+    fun `인증_여부_확인_예외`() {
+        val result = RuntimeException("error")
+        every { repository.checkUserVerified() } throws result
+        runTest {
+            var thrown = false
+
+            try {
+                useCase()
+            } catch (e: Throwable) {
+                thrown = true
+                assertEquals(result.message, e.message)
+            }
+
+            assertEquals(true, thrown)
+
+            verify(exactly = 1) {
+                repository.checkUserVerified()
+            }
+        }
+    }
+}

--- a/domain/src/test/java/com/gyleedev/domain/usecase/DeleteFriendUseCaseTest.kt
+++ b/domain/src/test/java/com/gyleedev/domain/usecase/DeleteFriendUseCaseTest.kt
@@ -1,0 +1,60 @@
+package com.gyleedev.domain.usecase
+
+import com.gyleedev.domain.model.ChangeRelationResult
+import com.gyleedev.domain.model.RelatedUserLocalData
+import com.gyleedev.domain.repository.UserRepository
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+// Repository에서 exception을 catch 해서 ChangeRelationResult.FAILURE를 리턴하기 때문에 예외처리 테스트 필요 없음
+class DeleteFriendUseCaseTest {
+
+    private lateinit var useCase: DeleteFriendUseCase
+
+    @MockK
+    lateinit var repository: UserRepository
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        useCase = DeleteFriendUseCase(repository)
+    }
+
+    @Test
+    fun `친구_삭제_요청_성공`() {
+        val friend = RelatedUserLocalData(uid = "uid")
+        val expected = ChangeRelationResult.SUCCESS
+        coEvery { repository.deleteFriendRequest(friend) } returns expected
+        runTest {
+            val result = useCase(friend)
+
+            assertEquals(expected, result)
+
+            coVerify(exactly = 1) {
+                repository.deleteFriendRequest(friend)
+            }
+        }
+    }
+
+    @Test
+    fun `친구_삭제_요청_실패`() {
+        val friend = RelatedUserLocalData(uid = "uid")
+        val expected = ChangeRelationResult.FAILURE
+        coEvery { repository.deleteFriendRequest(friend) } returns expected
+        runTest {
+            val result = useCase(friend)
+
+            assertEquals(expected, result)
+
+            coVerify(exactly = 1) {
+                repository.deleteFriendRequest(friend)
+            }
+        }
+    }
+}

--- a/domain/src/test/java/com/gyleedev/domain/usecase/DeleteMessageFromLocalUseCaseTest.kt
+++ b/domain/src/test/java/com/gyleedev/domain/usecase/DeleteMessageFromLocalUseCaseTest.kt
@@ -1,0 +1,39 @@
+package com.gyleedev.domain.usecase
+
+import com.gyleedev.domain.repository.MessageRepository
+import io.mockk.MockKAnnotations
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+// Unit 리턴되는 함수기 때문에 값을 비교할 필요는 없음
+// 예외도 로컬을 찌르는 함수기 때문에 체크할 필요 없음
+class DeleteMessageFromLocalUseCaseTest {
+
+    private lateinit var useCase: DeleteMessageFromLocalUseCase
+
+    @MockK
+    lateinit var repository: MessageRepository
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        useCase = DeleteMessageFromLocalUseCase(repository)
+    }
+
+    @Test
+    fun `로컬_메시지_삭제_성공`() = runTest {
+        val messageId = 1L
+
+        val result = useCase(messageId)
+
+        assertEquals(Unit, result)
+
+        coVerify(exactly = 1) {
+            repository.deleteLocalMessage(messageId)
+        }
+    }
+}

--- a/domain/src/test/java/com/gyleedev/domain/usecase/DeleteMessageUseCaseTest.kt
+++ b/domain/src/test/java/com/gyleedev/domain/usecase/DeleteMessageUseCaseTest.kt
@@ -1,0 +1,80 @@
+package com.gyleedev.domain.usecase
+
+import com.gyleedev.domain.model.MessageData
+import com.gyleedev.domain.model.ProcessResult
+import com.gyleedev.domain.repository.MessageRepository
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class DeleteMessageUseCaseTest {
+
+    private lateinit var useCase: DeleteMessageUseCase
+
+    @MockK
+    lateinit var repository: MessageRepository
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        useCase = DeleteMessageUseCase(repository)
+    }
+
+    @Test
+    fun `메시지_삭제_요청_성공`() = runTest {
+        val message = MessageData(messageId = 1L)
+        val expected = ProcessResult.Success
+        coEvery { repository.deleteMessageRequest(message) } returns flowOf(expected)
+
+        val result = useCase(message)
+
+        assertEquals(expected, result)
+
+        coVerify(exactly = 1) {
+            repository.deleteMessageRequest(message)
+        }
+    }
+
+    @Test
+    fun `메시지_삭제_요청_실패`() = runTest {
+        val message = MessageData(messageId = 1L)
+        val expected = ProcessResult.Failure
+        coEvery { repository.deleteMessageRequest(message) } returns flowOf(expected)
+
+        val result = useCase(message)
+
+        assertEquals(expected, result)
+
+        coVerify(exactly = 1) {
+            repository.deleteMessageRequest(message)
+        }
+    }
+
+    @Test
+    fun `메시지_삭제_요청_예외`() = runTest {
+        val message = MessageData(messageId = 1L)
+        val error = RuntimeException("error")
+        coEvery { repository.deleteMessageRequest(message) } throws error
+
+        var thrown = false
+
+        try {
+            useCase(message)
+        } catch (e: Throwable) {
+            thrown = true
+            assertEquals(error.message, e.message)
+        }
+
+        assertEquals(true, thrown)
+
+        coVerify(exactly = 1) {
+            repository.deleteMessageRequest(message)
+        }
+    }
+}

--- a/feature/src/main/java/com/gyleedev/feature/chatroom/ChatRoomViewModel.kt
+++ b/feature/src/main/java/com/gyleedev/feature/chatroom/ChatRoomViewModel.kt
@@ -386,7 +386,7 @@ class ChatRoomViewModel @Inject constructor(
 
     fun deleteMessage(messageData: MessageData) {
         viewModelScope.launch {
-            deleteMessageUseCase(messageData).first()
+            deleteMessageUseCase(messageData)
         }
     }
 

--- a/feature/src/main/java/com/gyleedev/feature/friendlist/FriendListViewModel.kt
+++ b/feature/src/main/java/com/gyleedev/feature/friendlist/FriendListViewModel.kt
@@ -78,15 +78,15 @@ class FriendListViewModel @Inject constructor(
 
     private suspend fun getFriendsCount(): Long = getFriendsCountUseCase()
 
-    private fun getMyRelatedUsersFromRemote() {
-        viewModelScope.launch {
-            val request = getMyRelatedUserListFromRemoteUseCase().first()
-            if (request != null) {
-                addMyRelatedUsersToLocal(request)
-            }
+    // 리모트에서 아는 유저 리스트를 가져오고 로컬에 추가
+    private suspend fun getMyRelatedUsersFromRemote() {
+        val request = getMyRelatedUserListFromRemoteUseCase().first()
+        if (request != null) {
+            addMyRelatedUsersToLocal(request)
         }
     }
 
+    // 로컬에 아는 유저 리스트를 로컬에 추가
     private suspend fun addMyRelatedUsersToLocal(friends: List<RelatedUserRemoteData>) {
         addMyRelatedUsersUseCase(friends)
     }


### PR DESCRIPTION
- a~d 로 시작하는 유스케이스 중에 단일 함수를 호출하는 유스케이스의 테스트를 구현
- 도메인 유스케이스가 Flow 대신 불리언/결과 객체를 직접 반환하도록 정리하여 호출부에서 즉시 상태를 활용할 수 있게 수정 
- 변경된 반환 타입에 맞춰 ViewModel 처리 과정을 정리하고 불필요한 Flow 수집을 제거
- 주요 유스케이스에 성공/실패/예외 단위 테스트를 추가해 회귀 검증을 강화 